### PR TITLE
Adding callback data attribute for re-captcha callback support

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -62,7 +62,7 @@ class Plugin extends PluginBase
     public function registerPageSnippets()
     {
         return [
-           'Uniacid\Captcha\Components\Captcha' => 'captcha'
+           'Alxy\Captcha\Components\Captcha' => 'captcha'
         ];
     }
 

--- a/Plugin.php
+++ b/Plugin.php
@@ -55,6 +55,18 @@ class Plugin extends PluginBase
     }
 
     /**
+     * Registers component as a snippet to be used in Static Pages.
+     * 
+     * @return array
+     */
+    public function registerPageSnippets()
+    {
+        return [
+           'Uniacid\Captcha\Components\Captcha' => 'captcha'
+        ];
+    }
+
+    /**
      * Registers administrator permissions for this plugin
      *
      * @return array

--- a/components/captcha/default.htm
+++ b/components/captcha/default.htm
@@ -1,2 +1,2 @@
-<div class="g-recaptcha" data-sitekey="{{ settings.site_key }}"></div>
+<div class="g-recaptcha" data-callback="recaptchaCallback" data-sitekey="{{ settings.site_key }}"></div>
 <script type="text/javascript" src="https://www.google.com/recaptcha/api.js?hl={{ settings.lang }}"></script>


### PR DESCRIPTION
Figure I should PR this so it's not overwritten on any plugin updates accidentally as I use it on my end for verification of user response via JS callback when needed.

> Optional. The name of your callback function to be executed when the user submits a successful CAPTCHA response. The user's response, g-recaptcha-response, will be the input for your callback function.
